### PR TITLE
Replace deprecated use of $.browser

### DIFF
--- a/source/jquery.singlemask.js
+++ b/source/jquery.singlemask.js
@@ -1,5 +1,13 @@
 (function ($) {
-  var pasteEventName = $.browser.msie ? 'paste' : 'input';
+  function getPasteEvent() {
+    var el = document.createElement('input'),
+
+    name = 'onpaste';
+    el.setAttribute(name, '');
+    return (typeof el[name] === 'function') ? 'paste' : 'input';
+  }
+
+  var pasteEventName = getPasteEvent();
 
   $.fn.singlemask = function (mask) {
     $(this).keydown(function (event) {


### PR DESCRIPTION
Using `$.browser` is deprecated since jQuery 1.3.

This is other way to get paste event name from browser.

Trying to fix you recomended me to see how jQuery Masked Input Plugin do.

Thanks for this plugin. I hope this can help :D 
