### PR TITLE
Fix problem when using the numpad

### DIFF
--- a/source/jquery.singlemask.js
+++ b/source/jquery.singlemask.js
@@ -24,6 +24,13 @@
         return;
       }
 
+      // Numpad key numbers starts on 96 (0) and ends on 105 (9)
+      // Somehow the String.fromCharCode doesn't knows that
+      // Subtracting 48 we have the 'standard' number code
+      if (key >= 96 && key <= 105) {
+        key = key - 48;
+      }
+
       return String.fromCharCode(key).match(mask);
     }).bind(pasteEventName, function () {
       this.value = $.grep(this.value, function (character) {


### PR DESCRIPTION
The numpad numbers' code are different from the standard numbers. The
code number starts in 96 (number 0) and ends in 105 (number 9).

The problem is in the String.fromCharCode function because it doesn't
recognize the numpad code numbers.

To fix that this commit was made to calculate the 'correct' key code to
be used in the String.fromCharCode function.
