### PR TITLE
Using preventDefault instead of return null values

### DIFF
--- a/source/jquery.singlemask.js
+++ b/source/jquery.singlemask.js
@@ -31,7 +31,9 @@
         key = key - 48;
       }
 
-      return String.fromCharCode(key).match(mask);
+      if (!String.fromCharCode(key).match(mask)) {
+        event.preventDefault();
+      };
     }).bind(pasteEventName, function () {
       this.value = $.grep(this.value, function (character) {
         return character.match(mask);


### PR DESCRIPTION
Returning null value on event's callback doesn't stop the event's
propagation and default behavior.
